### PR TITLE
[FE] 가운데 정렬 및 ScoreBoard 컴포넌트 일부 구현

### DIFF
--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -7190,6 +7190,19 @@
       "resolved": "https://registry.npmjs.org/hex-color-regex/-/hex-color-regex-1.1.0.tgz",
       "integrity": "sha512-l9sfDFsuqtOqKDsQdqrMRk0U85RZc0RtOR9yPI7mRVOa4FsR/BVnZ0shmQRM96Ji99kYZP/7hn1cedc1+ApsTQ=="
     },
+    "history": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+      "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "loose-envify": "^1.2.0",
+        "resolve-pathname": "^3.0.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0",
+        "value-equal": "^1.0.1"
+      }
+    },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
@@ -10075,6 +10088,15 @@
       "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
       "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="
     },
+    "mini-create-react-context": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mini-create-react-context/-/mini-create-react-context-0.4.1.tgz",
+      "integrity": "sha512-YWCYEmd5CQeHGSAKrYvXgmzzkrvssZcuuQDDeqkT+PziKGMgE+0MCCtcKbROzocGBG1meBLl2FotlRwf4gAzbQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.1",
+        "tiny-warning": "^1.0.3"
+      }
+    },
     "mini-css-extract-plugin": {
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.11.3.tgz",
@@ -12516,6 +12538,52 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.8.3.tgz",
       "integrity": "sha512-X8jZHc7nCMjaCqoU+V2I0cOhNW+QMBwSUkeXnTi8IPe6zaRWfn60ZzvFDZqWPfmSJfjub7dDW1SP0jaHWLu/hg=="
     },
+    "react-router": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",
+      "integrity": "sha512-smz1DUuFHRKdcJC0jobGo8cVbhO3x50tCL4icacOlcwDOEQPq4TMqwx3sY1TP+DvtTgz4nm3thuo7A+BK2U0Dw==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "hoist-non-react-statics": "^3.1.0",
+        "loose-envify": "^1.3.1",
+        "mini-create-react-context": "^0.4.0",
+        "path-to-regexp": "^1.7.0",
+        "prop-types": "^15.6.2",
+        "react-is": "^16.6.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
+    },
+    "react-router-dom": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.2.0.tgz",
+      "integrity": "sha512-gxAmfylo2QUjcwxI63RhQ5G85Qqt4voZpUXSEqCwykV0baaOTQDR1f0PmY8AELqIyVc0NEZUj0Gov5lNGcXgsA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2",
+        "history": "^4.9.0",
+        "loose-envify": "^1.3.1",
+        "prop-types": "^15.6.2",
+        "react-router": "5.2.0",
+        "tiny-invariant": "^1.0.2",
+        "tiny-warning": "^1.0.0"
+      }
+    },
     "react-scripts": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-4.0.3.tgz",
@@ -12951,6 +13019,11 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
+    },
+    "resolve-pathname": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+      "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
     },
     "resolve-url": {
       "version": "0.2.1",
@@ -14630,6 +14703,16 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
     },
+    "tiny-invariant": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.1.0.tgz",
+      "integrity": "sha512-ytxQvrb1cPc9WBEI/HSeYYoGD0kWnGEOR8RY6KomWLBVhqz0RgTwVO9dLrGz7dC+nN9llyI7OKAgRq8Vq4ZBSw=="
+    },
+    "tiny-warning": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+      "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
     "tmpl": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
@@ -15102,6 +15185,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "value-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+      "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/FE/src/App.js
+++ b/FE/src/App.js
@@ -1,34 +1,43 @@
-import { useContext, useState } from 'react';
-import { BrowserRouter as Router, Switch, Route, Link } from 'react-router-dom';
-import GlobalStyle from './GlobalStyle';
-import Home from './components/Home/Home';
-import Intro from './components/Intro/Intro';
-import InGame from './components/InGame/InGame';
-import NoMatch from './components/NoMatch/NoMatch';
+import { BrowserRouter as Router, Switch, Route, Link } from "react-router-dom";
+import GlobalStyle from "./GlobalStyle";
+import styled from "styled-components";
+import Home from "./components/Home/Home";
+import Intro from "./components/Intro/Intro";
+import InGame from "./components/InGame/InGame";
+import NoMatch from "./components/NoMatch/NoMatch";
 
 function App() {
-  return (
-    <>
-      <Router>
-        <GlobalStyle />
-        <Switch>
-          <Route path="/intro">
-            <Intro />
-          </Route>
-          <Route path="/ingame">
-            <InGame />
-          </Route>
-          <Route exact path="/">
-            <Home />
-          </Route>
-          <Route path="/image"></Route>
-          <Route path="*">
-            <NoMatch />
-          </Route>
-        </Switch>
-      </Router>
-    </>
-  );
+	return (
+		<>
+			<Router>
+				<GlobalStyle />
+				<Main>
+					<Switch>
+						<Route path="/intro">
+							<Intro />
+						</Route>
+						<Route path="/ingame">
+							<InGame />
+						</Route>
+						<Route exact path="/">
+							<Home />
+						</Route>
+						<Route path="/image"></Route>
+						<Route path="*">
+							<NoMatch />
+						</Route>
+					</Switch>
+				</Main>
+			</Router>
+		</>
+	);
 }
+
+const Main = styled.div`
+	background-image: url("image/mlbground_edit.jpg");
+	background-repeat: no-repeat;
+	min-width: 1280px;
+	min-height: 720px;
+`;
 
 export default App;

--- a/FE/src/GlobalStyle.jsx
+++ b/FE/src/GlobalStyle.jsx
@@ -1,18 +1,15 @@
-import { createGlobalStyle } from 'styled-components';
-import reset from 'styled-reset';
+import { createGlobalStyle } from "styled-components";
+import reset from "styled-reset";
 
 const GlobalStyle = createGlobalStyle`
   ${reset};
 
   body {
-    background-image: url("image/mlbground_edit.jpg");
-    background-repeat: no-repeat;
-    background-position: 20rem 5rem;
-    min-width: 1280px;
-    min-height: 720px;
     padding: 0;
     margin: 0;
     font-family: 'Noto Sans KR', sans-serif;
+    display:flex;
+    justify-content:center;
   }
 
   * {

--- a/FE/src/components/InGame/InGame.jsx
+++ b/FE/src/components/InGame/InGame.jsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import styled from "styled-components";
-import ScoreBoard from "./ScoreBoard";
+import ScoreBoard from "./ScoreBoard/ScoreBoard";
 
 const InGame = () => {
 	const [slideScoreBoard, toggleScoreBoard] = useState(false);

--- a/FE/src/components/InGame/InGame.jsx
+++ b/FE/src/components/InGame/InGame.jsx
@@ -1,10 +1,40 @@
-import { BrowserRouter as Router, Switch, Route, Link } from 'react-router-dom';
-import styled from 'styled-components';
+import { useState } from "react";
+import styled from "styled-components";
+import ScoreBoard from "./ScoreBoard";
 
 const InGame = () => {
-  return <StyledInGame></StyledInGame>;
+	const [slideScoreBoard, toggleScoreBoard] = useState(false);
+	const [isDark, setDark] = useState(false);
+	const clickMain = () => {
+		toggleScoreBoard(false);
+		setDark(false);
+	};
+	return (
+		<StyledInGame>
+			<ScoreBoard slide={slideScoreBoard} toggle={toggleScoreBoard} setDark={setDark} />
+			<Main onClick={clickMain} isDark={isDark}>
+				김 수한무 거북이와 두루미
+				<Ground />
+				<Record />
+			</Main>
+			<LineUp />
+		</StyledInGame>
+	);
 };
 
 export default InGame;
 
-const StyledInGame = styled.div``;
+const StyledInGame = styled.div`
+	position: relative;
+`;
+const Main = styled.div`
+	height: 720px;
+	filter: ${({ isDark }) => (isDark ? "brightness(20%)" : "")};
+	transition: 400ms;
+
+	font-size: 5rem;
+	color: white;
+`;
+const Ground = styled.div``;
+const Record = styled.div``;
+const LineUp = styled.div``;

--- a/FE/src/components/InGame/ScoreBoard.jsx
+++ b/FE/src/components/InGame/ScoreBoard.jsx
@@ -1,0 +1,38 @@
+import { useState } from "react";
+import styled from "styled-components";
+
+const ScoreBoard = ({ slide, toggle, setDark }) => {
+	return (
+		<StyledScoreBoard>
+			<NearChecker
+				onMouseEnter={() => {
+					toggle(true);
+					setDark(true);
+				}}
+			/>
+			<Table slide={slide} />
+		</StyledScoreBoard>
+	);
+};
+const StyledScoreBoard = styled.div``;
+const NearChecker = styled.div`
+	position: absolute;
+	width: 1280px;
+	height: 100px;
+`;
+const Table = styled.div`
+	position: absolute;
+	border: 1px solid red;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: 1100px;
+	height: 180px;
+	top: ${(props) => (props.slide ? "20px" : "-200px")};
+	left: 90px;
+	transition: 400ms;
+	z-index: 2;
+`;
+
+
+export default ScoreBoard;

--- a/FE/src/components/InGame/ScoreBoard/ScoreBoard.jsx
+++ b/FE/src/components/InGame/ScoreBoard/ScoreBoard.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import styled from "styled-components";
+import Table from "./Table";
 
 const ScoreBoard = ({ slide, toggle, setDark }) => {
 	return (
@@ -20,19 +21,5 @@ const NearChecker = styled.div`
 	width: 1280px;
 	height: 100px;
 `;
-const Table = styled.div`
-	position: absolute;
-	border: 1px solid red;
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	width: 1100px;
-	height: 180px;
-	top: ${(props) => (props.slide ? "20px" : "-200px")};
-	left: 90px;
-	transition: 400ms;
-	z-index: 2;
-`;
-
 
 export default ScoreBoard;

--- a/FE/src/components/InGame/ScoreBoard/Table.jsx
+++ b/FE/src/components/InGame/ScoreBoard/Table.jsx
@@ -1,0 +1,93 @@
+import styled from "styled-components";
+
+const Table = ({ slide }) => {
+	const inning = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, "R"];
+
+	return (
+		<StyledTable slide={slide}>
+			<thead>
+				<tr>
+					<th>&nbsp;</th>
+				</tr>
+				<tr>
+					<th>awayTeam</th>
+				</tr>
+				<tr>
+					<th>homeTeam</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					{inning.map((e) => (
+						<Inning key={e}>{e}</Inning>
+					))}
+				</tr>
+				<tr>
+					<td>0</td>
+					<td>0</td>
+					<td>0</td>
+					<td>0</td>
+					<td>0</td>
+					<td>0</td>
+					<td>1</td>
+					<td>0</td>
+					<td>0</td>
+					<td></td>
+					<td></td>
+					<td></td>
+					<Sum>1</Sum>
+				</tr>
+				<tr>
+					<td>3</td>
+					<td>3</td>
+					<td>5</td>
+					<td>0</td>
+					<td>1</td>
+					<td>2</td>
+					<td>0</td>
+					<td>0</td>
+					<td></td>
+					<td></td>
+					<td></td>
+					<td></td>
+					<Sum>14</Sum>
+				</tr>
+			</tbody>
+		</StyledTable>
+	);
+};
+
+const StyledTable = styled.table`
+	position: absolute;
+	border: 1px solid red;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: 1100px;
+	height: 180px;
+	top: ${(props) => (props.slide ? "20px" : "-200px")};
+	left: 90px;
+	transition: 400ms;
+
+	z-index: 2;
+
+	background-color: rgba(0,0,0,0.6);
+
+	color: white;
+	text-align: center;
+	font-size: 26px;
+	font-weight: bold;
+	th,
+	td {
+		padding: 10px;
+		width: 60px;
+	}
+`;
+const Inning = styled.th`
+	border-bottom: 1px solid white;
+`;
+const Sum = styled.td`
+	color: red;
+`;
+
+export default Table;

--- a/FE/src/components/Intro/Intro.jsx
+++ b/FE/src/components/Intro/Intro.jsx
@@ -9,7 +9,6 @@ const Intro = () => (
 );
 
 const Wrapper = styled.div`
-	width: 1280px;
 	height: 720px;
 	display: flex;
 	flex-direction: column;

--- a/FE/src/components/Intro/TeamSelect.jsx
+++ b/FE/src/components/Intro/TeamSelect.jsx
@@ -4,6 +4,7 @@ import Game from "./Game";
 
 const TeamSelect = () => {
 	const [gameList, setGameList] = useState([]);
+	const [isHover, setHover] = useState(false);
 	const [alertMessage, setAlertMessage] = useState("참가할 게임을 선택해주세요");
 	useEffect(() => {
 		fetch("https://baseball-ahpuh.herokuapp.com/games")
@@ -15,7 +16,9 @@ const TeamSelect = () => {
 	return (
 		<Wrapper>
 			<Alert>{alertMessage}</Alert>
-			<GameList>{gameList ? gameList.map((el, i) => <Game {...el} key={i} index={i} />) : "loading..."}</GameList>
+			<GameList isHover={isHover} onMouseEnter={() => setHover(true)} onMouseLeave={() => setHover(false)}>
+				{gameList ? gameList.map((el, i) => <Game {...el} key={i} index={i} />) : "loading..."}
+			</GameList>
 		</Wrapper>
 	);
 };
@@ -31,11 +34,22 @@ const Alert = styled.div`
 	color: #fff;
 `;
 const GameList = styled.ul`
-	height: 400px;
+	position: relative;
+	left: 15px;
+	height: 386px;
+	width: 745px;
 	overflow-y: scroll;
-	--ms-overflow-style: none;
 	::-webkit-scrollbar {
-		display: none;
+		background-color: #a6a7ab;
+		width: 13px;
+		border-radius: 10px;
+		display: ${(props) => (props.isHover ? "" : "none")};
+	}
+	::-webkit-scrollbar-thumb:vertical {
+		background-color: #4c4c4c;
+		border-radius: 10px;
+		border: 2px solid transparent;
+		background-clip: padding-box;
 	}
 `;
 


### PR DESCRIPTION
#25 
### 구현사항
- 가운데정렬
  - Main 컴포넌트 생성 및 모든 하위컴포넌트 Main밑으로 이동
  - background image 메인으로 이동
  - GlobalStyle에서 display:flex, justify-content를 이용해 가운데정렬
- ScoreBoard
  - 슬라이드
  - main?  Ground&Record부분 어두워지게
  - 표 틀
- Intro
  - 스크롤 스타일 조정
    - 현재 크롬만 적용
### 추가 구현 필요
- [x] ScoreBoard Table 을 채워줄 fetch & parse
- [ ] Intro GameList 스크롤 크롬의외의 브라우저에서의 스타일