### PR TITLE
[FE] LineUp 구현

### DIFF
--- a/FE/src/components/InGame/InGame.jsx
+++ b/FE/src/components/InGame/InGame.jsx
@@ -1,23 +1,25 @@
 import { useState } from "react";
 import styled from "styled-components";
 import ScoreBoard from "./ScoreBoard/ScoreBoard";
+import LineUp from "./LineUp/LineUp";
 
 const InGame = () => {
 	const [slideScoreBoard, toggleScoreBoard] = useState(false);
+	const [slideLineUp, toggleLineUp] = useState(false);
 	const [isDark, setDark] = useState(false);
 	const clickMain = () => {
 		toggleScoreBoard(false);
+		toggleLineUp(false);
 		setDark(false);
 	};
 	return (
 		<StyledInGame>
-			<ScoreBoard slide={slideScoreBoard} toggle={toggleScoreBoard} setDark={setDark} />
+			<ScoreBoard slide={slideScoreBoard} toggle={toggleScoreBoard} isDark={isDark} setDark={setDark} />
+			<LineUp slide={slideLineUp} toggle={toggleLineUp} isDark={isDark} setDark={setDark} />
 			<Main onClick={clickMain} isDark={isDark}>
-				김 수한무 거북이와 두루미
 				<Ground />
 				<Record />
 			</Main>
-			<LineUp />
 		</StyledInGame>
 	);
 };
@@ -26,6 +28,8 @@ export default InGame;
 
 const StyledInGame = styled.div`
 	position: relative;
+	overflow: hidden;
+	margin-top: 30px;
 `;
 const Main = styled.div`
 	height: 720px;
@@ -37,4 +41,3 @@ const Main = styled.div`
 `;
 const Ground = styled.div``;
 const Record = styled.div``;
-const LineUp = styled.div``;

--- a/FE/src/components/InGame/LineUp/LineUp.jsx
+++ b/FE/src/components/InGame/LineUp/LineUp.jsx
@@ -1,9 +1,9 @@
 import styled from "styled-components";
 import Table from "./Table";
 
-const ScoreBoard = ({ slide, toggle, isDark, setDark }) => {
+const LineUp = ({ slide, toggle, isDark, setDark }) => {
 	return (
-		<StyledScoreBoard>
+		<StyledLineUp>
 			<NearChecker
 				onMouseEnter={() => {
 					if (isDark) return;
@@ -12,14 +12,15 @@ const ScoreBoard = ({ slide, toggle, isDark, setDark }) => {
 				}}
 			/>
 			<Table slide={slide} />
-		</StyledScoreBoard>
+		</StyledLineUp>
 	);
 };
-const StyledScoreBoard = styled.div``;
+const StyledLineUp = styled.div``;
 const NearChecker = styled.div`
 	position: absolute;
 	width: 1280px;
 	height: 100px;
+	top: 620px;
 `;
 
-export default ScoreBoard;
+export default LineUp;

--- a/FE/src/components/InGame/LineUp/Table.jsx
+++ b/FE/src/components/InGame/LineUp/Table.jsx
@@ -1,0 +1,150 @@
+import styled from "styled-components";
+
+const Table = ({ slide }) => {
+	return (
+		<StyledTable slide={slide}>
+			<TableContent />
+			<TableContent />
+		</StyledTable>
+	);
+};
+
+const TableContent = () => {
+	return (
+		<StyledTableContent>
+			<caption>Team name</caption>
+			<thead>
+				<tr>
+					<th>타자</th>
+					<th>타석</th>
+					<th>안타</th>
+					<th>아웃</th>
+					<th>평균</th>
+				</tr>
+			</thead>
+			<tbody>
+				<tr>
+					<td>김광현</td>
+					<td>2</td>
+					<td>1</td>
+					<td>1</td>
+					<td>0.500</td>
+				</tr>
+				<tr>
+					<td>김광현</td>
+					<td>2</td>
+					<td>1</td>
+					<td>1</td>
+					<td>0.500</td>
+				</tr>
+				<tr>
+					<td>김광현</td>
+					<td>2</td>
+					<td>1</td>
+					<td>1</td>
+					<td>0.500</td>
+				</tr>
+				<tr>
+					<td>김광현</td>
+					<td>2</td>
+					<td>1</td>
+					<td>1</td>
+					<td>0.500</td>
+				</tr>
+				<tr>
+					<td>김광현</td>
+					<td>2</td>
+					<td>1</td>
+					<td>1</td>
+					<td>0.500</td>
+				</tr>
+				<tr>
+					<td>김광현</td>
+					<td>2</td>
+					<td>1</td>
+					<td>1</td>
+					<td>0.500</td>
+				</tr>
+				<tr>
+					<td>김광현</td>
+					<td>2</td>
+					<td>1</td>
+					<td>1</td>
+					<td>0.500</td>
+				</tr>
+				<tr>
+					<td>김광현</td>
+					<td>2</td>
+					<td>1</td>
+					<td>1</td>
+					<td>0.500</td>
+				</tr>
+				<tr>
+					<td>김광현</td>
+					<td>2</td>
+					<td>1</td>
+					<td>1</td>
+					<td>0.500</td>
+				</tr>
+				<Total>
+					<td>Totals</td>
+					<td>18</td>
+					<td>9</td>
+					<td>9</td>
+					<td>0.500</td>
+				</Total>
+			</tbody>
+		</StyledTableContent>
+	);
+};
+
+const StyledTable = styled.div`
+	position: absolute;
+	border: 3px solid #fff;
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	width: 960px;
+	height: 610px;
+	top: ${(props) => (props.slide ? "55px" : "720px")};
+	left: 160px;
+	transition: 400ms;
+
+	z-index: 2;
+
+	background-color: rgba(0, 0, 0, 0.8);
+`;
+
+const StyledTableContent = styled.table`
+	color: white;
+
+	text-align: center;
+	font-size: 24px;
+	caption {
+		font-size: 32px;
+		font-weight: bold;
+		padding: 10px;
+		border-bottom: 3px solid #fff;
+	}
+	th,
+	td {
+		padding: 12px 18px;
+	}
+	th {
+		color: gray;
+		border-bottom: 2px solid #494949;
+	}
+	tr + tr {
+		border-top: 1px solid #b6b6b6;
+	}
+	& + & {
+		border-left: 3px solid #fff;
+	}
+`;
+
+const Total = styled.tr`
+	font-weight: bold;
+	padding: 12px 20px;
+`;
+
+export default Table;

--- a/FE/src/components/InGame/ScoreBoard/Table.jsx
+++ b/FE/src/components/InGame/ScoreBoard/Table.jsx
@@ -59,7 +59,7 @@ const Table = ({ slide }) => {
 
 const StyledTable = styled.table`
 	position: absolute;
-	border: 1px solid red;
+	border: 3px solid #fff;
 	display: flex;
 	justify-content: center;
 	align-items: center;
@@ -71,7 +71,7 @@ const StyledTable = styled.table`
 
 	z-index: 2;
 
-	background-color: rgba(0,0,0,0.6);
+	background-color: rgba(0, 0, 0, 0.8);
 
 	color: white;
 	text-align: center;


### PR DESCRIPTION
#31 
### 구현상황
- LineUp 스타일 전반, 슬라이드, 클릭 이벤트
- ScoreBoard border 조정
### 추가 구현 필요
- [x] LineUp Table 을 채워줄 fetch & parse
### 예시
![image](https://user-images.githubusercontent.com/70461368/117113774-eb227a80-adc5-11eb-97f8-e6460cd9b9e4.png)
![image](https://user-images.githubusercontent.com/70461368/117113928-2329bd80-adc6-11eb-9d37-a6d82bba6813.png)
### To Goody
- 컴포넌트 개발하는 건 전혀 힘에 부치지 않습니다!
- 오히려 제가 컴포넌트를 다 개발해서 구디가 공부가 안될까 걱정이네요...
- Oauth나 Router의 올바른 활용, 혹은 다른 같이 공부/구현할 부분 있으면 언제든지 말씀해주세요!